### PR TITLE
refactor: githubUserResponseDto getFollowing error and Bean error

### DIFF
--- a/src/main/java/com/haltebogen/gittalk/config/WebSecurityConfig.java
+++ b/src/main/java/com/haltebogen/gittalk/config/WebSecurityConfig.java
@@ -38,10 +38,10 @@ public class WebSecurityConfig {
             "/auth/github/callback"
     };
 
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        return configuration.getAuthenticationManager();
-    }
+//    @Bean
+//    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+//        return configuration.getAuthenticationManager();
+//    }
 
 
     @Bean

--- a/src/main/java/com/haltebogen/gittalk/config/WebSecurityConfig.java
+++ b/src/main/java/com/haltebogen/gittalk/config/WebSecurityConfig.java
@@ -38,11 +38,6 @@ public class WebSecurityConfig {
             "/auth/github/callback"
     };
 
-//    @Bean
-//    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-//        return configuration.getAuthenticationManager();
-//    }
-
 
     @Bean
     SecurityFilterChain defaultSecurityFilterChain(

--- a/src/test/java/com/haltebogen/gittalk/service/MemberServiceTest.java
+++ b/src/test/java/com/haltebogen/gittalk/service/MemberServiceTest.java
@@ -45,7 +45,7 @@ public class MemberServiceTest {
             assertThat(githubUserResponseDto.getLogin()).isEqualTo(member.getNickName());
             assertThat(githubUserResponseDto.getCompany()).isEqualTo(member.getCompany());
             assertThat(githubUserResponseDto.getFollowers()).isEqualTo(member.getFollowersNum());
-            assertThat(githubUserResponseDto.getFollowings()).isEqualTo(member.getFollowingsNum());
+            assertThat(githubUserResponseDto.getFollowing()).isEqualTo(member.getFollowingsNum());
             assertThat(githubUserResponseDto.getFollowers_url()).isEqualTo(member.getFollowersUrl());
             assertThat(githubUserResponseDto.getFollowings_url()).isEqualTo(member.getFollowingUrl());
             assertThat(ProviderType.GITHUB).isEqualTo(member.getProviderType());


### PR DESCRIPTION
## What is this PR do?
- `Introduction`: ex) getFollowing field 이름 수정 및 Bean error 수정
- `Notion Ticket`: [notion link]()
- `Figma`: [figma link]()

## Changes
- [x] : githubUserResponseDto field naming 수정
- [x] : AuthenticationManager Bean 수정
