### PR TITLE
refactor: chat-config refactoring

### DIFF
--- a/src/main/java/com/haltebogen/gittalk/config/MongoConfig.java
+++ b/src/main/java/com/haltebogen/gittalk/config/MongoConfig.java
@@ -23,10 +23,13 @@ public class MongoConfig extends AbstractMongoClientConfiguration {
         return mongo;
     }
 
-    @Bean
-    public MongoDatabaseFactory mongoDatabaseFactory() {
-        return new SimpleMongoClientDatabaseFactory(MongoClients.create(), "database");
-    }
+    /**
+     * Bean error -> register multiple bean problem
+     */
+//    @Bean
+//    public MongoDatabaseFactory mongoDatabaseFactory() {
+//        return new SimpleMongoClientDatabaseFactory(MongoClients.create(), "database");
+//    }
 
     @Bean
     public MongoClient mongoClient() {

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatMessage.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatMessage.java
@@ -1,9 +1,7 @@
 package com.haltebogen.gittalk.entity.chat;
 
-import com.haltebogen.gittalk.dto.member.ChatMemberResponseDto;
 import com.mongodb.lang.Nullable;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -24,7 +22,6 @@ public class ChatMessage {
     private List<String> participantId;
     private String sender;
     private String chatRoomId;
-
     private String message;
     private MessageStatus messageStatus;
 

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoom.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoom.java
@@ -32,6 +32,4 @@ public class ChatRoom {
 
     @LastModifiedDate
     LocalDateTime editedAt;
-
-
 }

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoom.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoom.java
@@ -1,8 +1,7 @@
 package com.haltebogen.gittalk.entity.chat;
 
-import com.haltebogen.gittalk.dto.member.ChatMemberResponseDto;
+import com.haltebogen.gittalk.dto.member.MemberDetailResponseDto;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -26,7 +25,7 @@ public class ChatRoom {
 
     private List<ChatMessage> messages;
 
-    private List<ChatMemberResponseDto> users;
+    private List<MemberDetailResponseDto> users;
 
     @CreatedDate
     LocalDateTime createdAt;

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomMedia.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomMedia.java
@@ -11,7 +11,6 @@ public class ChatRoomMedia {
 
     @Id
     private String _id;
-
     private String chatRoomId;
     private MediaType mediaType;
     private String uri;

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomParticipant.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomParticipant.java
@@ -6,7 +6,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,11 +18,8 @@ public class ChatRoomParticipant {
     private List<String> memberId;
     private String chatRoomId;
     private String name;
-
-
     @CreatedDate
     private LocalDateTime createdAt;
-
     private LocalDateTime lastReadAt;
 
     @Builder

--- a/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomParticipant.java
+++ b/src/main/java/com/haltebogen/gittalk/entity/chat/ChatRoomParticipant.java
@@ -16,10 +16,8 @@ public class ChatRoomParticipant {
 
     @Id
     private String _id;
-
     private List<String> memberId;
     private String chatRoomId;
-
     private String name;
 
 

--- a/src/main/java/com/haltebogen/gittalk/service/user/MemberService.java
+++ b/src/main/java/com/haltebogen/gittalk/service/user/MemberService.java
@@ -21,7 +21,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -75,8 +74,7 @@ public class MemberService {
         List<SearchGithubFollowResponseDto> results = new ArrayList<>();
         for (SearchGithubFollowResponseDto searchGithubFollowResponseDto: githubFollowsData
              ) {
-            if (searchGithubFollowResponseDto.getNickName().contains(keyword) ||
-            searchGithubFollowResponseDto.getEmail().contains(keyword)) {
+            if (String.format(searchGithubFollowResponseDto.getNickName()).contains(keyword)) {
                 results.add(searchGithubFollowResponseDto);
             }
         }


### PR DESCRIPTION
## What is this PR do?
- `Introduction`: chat config 리팩토링, style 수정


## Changes
- [x] : ChatMemberResponseDto 에서 SearchGithubFollowResponseDxato naming 수정
- [x] : dto field 특성상 isFollowing, isFollower, isMember 3가지의 필드는 Chatting에서 사용할 사항이 없음.
- [x] : unused module 및 공백 제거
- [x] :  mongoDbFactory bean error
- [x] : search 검색 조건 수정 -> email 검색조건에서 제외 
